### PR TITLE
Add cache control to version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # COVID-19 Growth Tracker
 
 ![Node.js CI](https://github.com/travishuff/covid-growth-rates/workflows/Node.js%20CI/badge.svg)
-![Version](https://img.shields.io/github/package-json/v/travishuff/covid-growth-rates?label=version)
+![Version](https://img.shields.io/github/package-json/v/travishuff/covid-growth-rates?label=version&cacheSeconds=300)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/80e2fa0b-df3c-4024-bae7-ac82e706c4f7/deploy-status)](https://app.netlify.com/projects/covid-growth-tracker/deploys)
 
 ## Overview


### PR DESCRIPTION
Summary:
- Add cacheSeconds to the version badge URL so it refreshes more reliably

Tests:
- Not run (README-only change)